### PR TITLE
Conditional Comments support

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,2 +1,2 @@
 'use strict';
-module.exports = /<!--((?:.|\s)*?)-->/g;
+module.exports = /<!--(?!\s*\[if)((?:.|\s)*?)-->/g;

--- a/test.js
+++ b/test.js
@@ -6,10 +6,6 @@ var html = '<!DOCTYPE html><!--[if lt IE 7]>      <html class="no-js lt-ie9 lt-i
 
 it('html should match the regex', function() {
   var result = htmlCommentRegex.exec(html);
-  assert.deepEqual(result[0], '<!--[if lt IE 7]>      <html class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->');
-  assert.deepEqual(result[1], '[if lt IE 7]>      <html class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]');
-
-  result = htmlCommentRegex.exec(html);
   assert.deepEqual(result[0], '<!-- normal comment 1 -->');
   assert.deepEqual(result[1], ' normal comment 1 ');
 


### PR DESCRIPTION
html-comment-regex should carefully treat conditional comments that offer advantages over scripted browser detection techniques. Conditional comments make it easy to detect earlier versions of IE. 

Format of conditional comments: 

```
<!--[if IE 8]>
<p>Welcome to Internet Explorer 8.</p>
<![endif]-->
```

This PR modifies regexp itself and tests (unfortunately) in order to support conditional comments. 
